### PR TITLE
Fix MKS MINI 12864 blanking on SD write with MKS TinyBee

### DIFF
--- a/src/sd_ESP32.cpp
+++ b/src/sd_ESP32.cpp
@@ -33,6 +33,7 @@ SdFile workDir;
 dir_t dir_info;
 SdVolume sd_volume;
 
+bool sd_busy_lock = false;
 
 ESP_SD::ESP_SD()
 {

--- a/src/sd_ESP32.h
+++ b/src/sd_ESP32.h
@@ -22,6 +22,9 @@
 
 #ifndef _ESP_SD_H_
 #define _ESP_SD_H_
+
+extern bool sd_busy_lock;
+
 class ESP_SD
 {
 public:

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -1239,10 +1239,12 @@ void Web_Server::WebUpdateUpload ()
 //direct SD files list//////////////////////////////////////////////////
 void Web_Server::handle_direct_SDFileList()
 {
+    sd_busy_lock = true;
     //this is only for admin an user
     if (is_authenticated() == LEVEL_GUEST) {
         _upload_status=UPLOAD_STATUS_NONE;
         _webserver->send(401, "application/json", "{\"status\":\"Authentication failed!\"}");
+        sd_busy_lock = false;
         return;
     }
 
@@ -1259,6 +1261,7 @@ void Web_Server::handle_direct_SDFileList()
     if (state != 1) {
         _webserver->sendHeader("Cache-Control","no-cache");
         _webserver->send(200, "application/json", "{\"status\":\"No SD Card\"}");
+        sd_busy_lock = false;
         return;
     }
 
@@ -1348,6 +1351,7 @@ void Web_Server::handle_direct_SDFileList()
         s+=  " does not exist on SD Card\"}";
         _webserver->sendHeader("Cache-Control","no-cache");
         _webserver->send(200, "application/json", s.c_str());
+        sd_busy_lock = false;
         return;
     }
     if (list_files) {
@@ -1403,11 +1407,14 @@ void Web_Server::handle_direct_SDFileList()
     _webserver->sendHeader("Cache-Control","no-cache");
     _webserver->send (200, "application/json", jsonfile.c_str());
     _upload_status=UPLOAD_STATUS_NONE;
+    sd_busy_lock = false;
 }
 
 //SD File upload with direct access to SD///////////////////////////////
 void Web_Server::SDFile_direct_upload()
 {
+    sd_busy_lock = true;
+
     static ESP_SD sdfile;
     static String upload_filename;
     //this is only for admin and user
@@ -1507,7 +1514,11 @@ void Web_Server::SDFile_direct_upload()
         if (sdfile.exists (upload_filename.c_str()) ) {
             sdfile.remove (upload_filename.c_str());
         }
+        sd_busy_lock = false;
+    }else if(_upload_status == UPLOAD_STATUS_SUCCESSFUL) {
+        sd_busy_lock = false;
     }
+
     Esp3DLibConfig::wait(0);
 }
 #endif


### PR DESCRIPTION
As implemented by Makerbase, fix for MKS_MINI_12864 v3 LCD screen blanking when SD card is accessed