### PR TITLE
Allow Marlin to relocate its HAL

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP3DLib
-version=1.0.11
+version=1.0.12
 author=Luc Lebosse
 maintainer=Luc Lebosse, <support@tech-hunters.com>
 sentence=A 3D printer front end for ESP boards.

--- a/src/esp3dlibconfig.h
+++ b/src/esp3dlibconfig.h
@@ -30,6 +30,18 @@
 #endif
 #define MARLIN_HAL_PATH(PATH) HAL_PATH(HALHOME, PATH)
 #define MARLIN_PATH(PATH) ESP_XSTR(SRCHOME/PATH)
+
+#if 0
+#define HAL_INCLUDE MARLIN_HAL_PATH(hal-file.h)
+#define SRC_INCLUDE MARLIN_PATH(src-file.h)
+static_assert(false,
+  " SRCHOME='" ESP_XSTR(SRCHOME) "'"
+  " HALHOME='" ESP_XSTR(HALHOME) "'"
+  " HAL_INCLUDE='" ESP_XSTR(HAL_INCLUDE) "'"
+  " SRC_INCLUDE='" ESP_XSTR(SRC_INCLUDE) "'"
+);
+#endif
+
 #include MARLIN_PATH(inc/MarlinConfigPre.h)
 #undef DISABLED
 #undef _BV

--- a/src/esp3dlibconfig.h
+++ b/src/esp3dlibconfig.h
@@ -22,8 +22,14 @@
 #define ESP_XSTR_(M) #M
 #define ESP_XSTR(M) ESP_XSTR_(M)
 #endif
-#define MARLIN_HAL_PATH(PATH) HAL_PATH( ../../../../../Marlin/src/HAL, PATH)
-#define MARLIN_PATH(PATH) ESP_XSTR(../../../../../Marlin/src/PATH)
+#ifndef SRCHOME
+#define SRCHOME ../../../../../Marlin/src
+#endif
+#ifndef HALHOME
+#define HALHOME SRCHOME/HAL
+#endif
+#define MARLIN_HAL_PATH(PATH) HAL_PATH(HALHOME, PATH)
+#define MARLIN_PATH(PATH) ESP_XSTR(SRCHOME/PATH)
 #include MARLIN_PATH(inc/MarlinConfigPre.h)
 #undef DISABLED
 #undef _BV

--- a/src/esp3dlibconfig.h
+++ b/src/esp3dlibconfig.h
@@ -46,7 +46,7 @@ static_assert(false,
 #undef DISABLED
 #undef _BV
 //version
-#define LIB_VERSION "1.0.11"
+#define LIB_VERSION "1.0.12"
 
 //Allow to override the default core used by ESP3DLIB
 #ifndef ESP3DLIB_RUNNING_CORE


### PR DESCRIPTION
We might (or do) want to change the `HAL_PATH` macro so it includes the `HAL` folder name, and later we might move the HAL to a different location within the project. For example, if we decide to build it as a library it may be moved into a root `lib` folder.

To wit:
```cpp
#define HAL_PATH(PATH, NAME) XSTR(PATH/HAL/AVR/NAME)
```

This PR adds `SRCHOME` and `HALHOME` preprocessor macros so that these locations can be overridden by defines added to our `features.ini` file, like so:

```ini
(ESP3D_)?WIFISUPPORT = AsyncTCP, ESP Async WebServer
                       ESP3DLib=https://github.com/luc-github/ESP3DLib/archive/master.zip
                       arduinoWebSockets=links2004/WebSockets@2.3.4
                       luc-github/ESP32SSDP@1.1.1
                       lib_ignore=ESPAsyncTCP
                       build_flags=-DSRCHOME=${platformio.src_dir}/src -DHALHOME=SRCHOME
```

The changes made to `esp3dlibconfig.h` allow for an elegant fallback to the old `HAL_PATH` behavior and location so that builds of older versions of Marlin will continue to work as usual.

Also, if 1.0.11 and 1.0.12 can be tagged in this repo, then we can specify a version to pull down, if for some reason that becomes necessary in the future.

Thanks and have a great day!