### PR TITLE
update src/sd_ESP32.cpp for latest marlin bugfix-2.1.x code

### DIFF
--- a/docs/html/sd___e_s_p32_8cpp_source.html
+++ b/docs/html/sd___e_s_p32_8cpp_source.html
@@ -122,7 +122,7 @@ $(document).ready(function(){initNavTree('sd___e_s_p32_8cpp_source.html',''); in
 <div class="line"><a name="l00053"></a><span class="lineno">   53</span>&#160;}</div>
 <div class="line"><a name="l00054"></a><span class="lineno">   54</span>&#160; </div>
 <div class="line"><a name="l00055"></a><span class="lineno">   55</span>&#160;int8_t <a class="code" href="class_e_s_p___s_d.html#a6aaf0c538574f5a4f58df66e78cad9e1">ESP_SD::card_status</a>(){</div>
-<div class="line"><a name="l00056"></a><span class="lineno">   56</span>&#160;<span class="keywordflow">if</span> (!IS_SD_INSERTED() || !card.isMounted()) <span class="keywordflow">return</span> 0; <span class="comment">//No sd</span></div>
+<div class="line"><a name="l00056"></a><span class="lineno">   56</span>&#160;<span class="keywordflow">if</span> (!card.isInserted() || !card.isMounted()) <span class="keywordflow">return</span> 0; <span class="comment">//No sd</span></div>
 <div class="line"><a name="l00057"></a><span class="lineno">   57</span>&#160;<span class="keywordflow">if</span> ( card.isPrinting() || card.isFileOpen() ) <span class="keywordflow">return</span> -1; <span class="comment">// busy</span></div>
 <div class="line"><a name="l00058"></a><span class="lineno">   58</span>&#160;<span class="keywordflow">return</span> 1; <span class="comment">//ok</span></div>
 <div class="line"><a name="l00059"></a><span class="lineno">   59</span>&#160;}</div>

--- a/src/sd_ESP32.cpp
+++ b/src/sd_ESP32.cpp
@@ -63,7 +63,11 @@ int8_t ESP_SD::card_status(bool forcemount)
     if(!card.isMounted() || forcemount) {
         card.mount();
     }
-    if (!IS_SD_INSERTED() || !card.isMounted()) {
+    #ifdef IS_SD_INSERTED
+      if (!IS_SD_INSERTED() || !card.isMounted()) {
+    #else
+      if (!card.isInserted() || !card.isMounted()) {
+    #endif
         return 0;    //No sd
     }
     if ( card.isPrinting() || card.isFileOpen() ) {


### PR DESCRIPTION
Marlin commit https://github.com/MarlinFirmware/Marlin/commit/5c0e8d594d343d4e38f6d2254916077e0f3a3c7d removed IS_SD_INSERTED in favour of  card.isSDCardInserted

Added a simple preprocessor test for IS_SD_INSERTED if it is defined then use it, otherwise use the new card.isSDCardInserted. 

This maintains compatibility with older and newest Marlin code.

